### PR TITLE
Make Advanced Matching configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,12 @@ return [
      * Enable or disable script rendering. Useful for local development.
      */
     'enabled' => env('FACEBOOK_PIXEL_ENABLED', false),
-    
+
+    /*
+     * Enable or disable advanced matching. Useful for adjusting user privacy.
+     */
+    'advanced_matching_enabled' => env('FACEBOOK_PIXEL_ADVANCED_MATCHING_ENABLED', true),
+
     /*
      * This is used to test server events
      */

--- a/config/facebook-pixel.php
+++ b/config/facebook-pixel.php
@@ -22,6 +22,11 @@ return [
     'enabled' => env('FACEBOOK_PIXEL_ENABLED', false),
 
     /*
+     * Enable or disable advanced matching. Useful for adjusting user privacy.
+     */
+    'advanced_matching_enabled' => env('FACEBOOK_PIXEL_ADVANCED_MATCHING_ENABLED', true),
+
+    /*
      * This is used to test server events
      */
     'test_event_code' => env('FACEBOOK_TEST_EVENT_CODE'),

--- a/resources/views/head.blade.php
+++ b/resources/views/head.blade.php
@@ -9,7 +9,7 @@
             t.src=v;s=b.getElementsByTagName(e)[0];
             s.parentNode.insertBefore(t,s)}(window, document,'script',
             'https://connect.facebook.net/en_US/fbevents.js');
-    @if($userData)
+    @if($advancedMatchingEnabled && $userData)
         fbq('init', '{{ $pixelId }}', {em: '{{ $userData['em'] }}', external_id: {{ $userData['external_id'] }}});
     @else
         fbq('init', '{{ $pixelId }}');

--- a/src/FacebookPixel.php
+++ b/src/FacebookPixel.php
@@ -24,6 +24,8 @@ class FacebookPixel
 
     private bool $enabled;
 
+    private bool $advancedMatchingEnabled;
+
     private string $pixelId;
 
     private ?string $token;
@@ -43,6 +45,7 @@ class FacebookPixel
     public function __construct()
     {
         $this->enabled = config('facebook-pixel.enabled');
+        $this->advancedMatchingEnabled = config('facebook-pixel.advanced_matching_enabled');
         $this->pixelId = config('facebook-pixel.facebook_pixel_id');
         $this->token = config('facebook-pixel.token');
         $this->sessionKey = config('facebook-pixel.sessionKey');
@@ -76,6 +79,11 @@ class FacebookPixel
     public function isEnabled(): bool
     {
         return $this->enabled;
+    }
+
+    public function isAdvancedMatchingEnabled(): bool
+    {
+        return $this->advancedMatchingEnabled;
     }
 
     public function enable(): void

--- a/src/ScriptViewCreator.php
+++ b/src/ScriptViewCreator.php
@@ -29,6 +29,7 @@ class ScriptViewCreator
 
         return $view
             ->with('enabled', $this->facebookPixel->isEnabled())
+            ->with('advancedMatchingEnabled', $this->facebookPixel->isAdvancedMatchingEnabled())
             ->with('pixelId', $this->facebookPixel->pixelId())
             ->with('eventLayer', $this->facebookPixel->getEventLayer())
             ->with('customEventLayer', $this->facebookPixel->getCustomEventLayer())


### PR DESCRIPTION
Advanced Matching as a default comes with sending user email address and user_id from Laravel. I noticed that some example privacy policies mention usage of the Meta Pixel to be anonymous so IMO this should be configurable.